### PR TITLE
fix markdown headers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 # AspNet Web CLI
 
-##Summary
+## Summary
 Web CLI tool for Asp.Net Core using JQuery Terminal and SignalR. Pass commands to .Net Core backend for processing with realtime updates pushed back to the terminal client. Source includes 'ping' command however can easily be extended to handle other commands and tasks.
 
-##Demo
+## Demo
 [Click here for video](https://cdn.whole.school/videos/WebCLI.mp4)
 
 Interactive demo available soon.
 
-##Architecture
+## Architecture
 
 - DotNetCore 1.0
 - Asp.Net MVC 6
 - SignalrR 3.0 alpha
 - Jquery Terminal (https://github.com/jcubic/jquery.terminal)
 
-##Tooling
+## Tooling
 
 - Visual Studio 2015
 - DotNetCore CLI


### PR DESCRIPTION
The headers in markdown require space.